### PR TITLE
remove need for params on 1st request in server-initiated

### DIFF
--- a/docs/Specification/Server-initiated.md
+++ b/docs/Specification/Server-initiated.md
@@ -1,10 +1,10 @@
 ## Server-initiated protocol
 
-In the server-initiated variant of the challenge-response protocol, the first step is the browser requesting a login from the server using a certain `cid`. The server answers the browser, which in turn displays an SSB URI which the SSB peer knows how to open.
+In the server-initiated variant of the challenge-response protocol, the first step is the browser requesting a login from the server without any input data. The server answers the browser, which in turn displays an SSB URI which the SSB peer knows how to open.
 
-The primary difference between this variant and the previous one is that the muxrpc async RPC is reversed. Previously, the server called `httpAuth.requestSolution` **on the client**. In this variant, client calls `httpAuth.sendSolution` **on the server**. The response is also different. In the previous case, the client's response is expected to be the `sol`. In this variant, the `sol` argument is provided by the client and the server's response is expected to be `true`.
+The primary difference between this variant and the previous one is that the muxrpc async RPC call direction is reversed. Previously, the server called `httpAuth.requestSolution` **on the client**. In this variant, the client calls `httpAuth.sendSolution` **on the server**. The response is also different. In the previous case, the client's response is expected to be the `sol`. In this variant, the `sol` argument is provided by the client and the server's response is expected to be `true`.
 
-The secondary difference with this variant is the addition of [Server-Sent Events](https://html.spec.whatwg.org/multipage/server-sent-events.html) between the browser and the server, to update the browser when the muxrpc protocol succeeds.
+The secondary difference with this variant is the addition of [Server-Sent Events](https://html.spec.whatwg.org/multipage/server-sent-events.html) (SSE) between the browser and the server, to update the browser when the muxrpc protocol succeeds.
 
 The UML sequence diagram for the whole server-initial protocol is shown below:
 
@@ -14,11 +14,11 @@ sequenceDiagram
   participant Uweb as Browser client
   participant Serv as SSB server `sid`
 
-  Uweb->>Serv: `https://${serverHost}/login?cid=${cid}`
+  Uweb->>Serv: `https://${serverHost}/login`
   activate Serv
   Note over Serv: Generates<br/>challenge `sc`
   Serv-->>Uweb: Displays `ssb:experimental?<br/>action=start-http-auth&sid=${sid}&sc=${sc}`
-  Uweb->>Serv: Subscribe to `/sse/login/${sc}`
+  Uweb->>Serv: SSE subscribe to `/sse/login/${sc}`
   Uweb->>Umux: Consumes SSB URI
   Note over Umux: Generates<br/>challenge `cc`
   Note over Umux: Generates<br/>signature `sol`


### PR DESCRIPTION
@keks I figured out with cryptix that there was one unnecessary parameter passed around, and he suggested asking from you your thoughts on whether it's still equally secure.

The difference is small and it's marked in red in the UML below. Basically, we realized that the 1st browser request doesn't have to pass any query parameter, because the SSB URI will either way pass arguments `sc` (server challenge) and `sid` (server ID), and then the SSB app that handles the URI will call the server via muxrpc, informing its `cid` (client ID), `cc` (client challenge), and `sol` (client's solution, the signature).

![diff](https://user-images.githubusercontent.com/90512/112626700-38abdf00-8e39-11eb-8a7d-24c75d267651.png)
