### PR TITLE
add optional multiserverAddress to SSB URI

### DIFF
--- a/docs/Specification/Server-initiated.md
+++ b/docs/Specification/Server-initiated.md
@@ -37,3 +37,9 @@ sequenceDiagram
     Note over Uweb: Stores auth token as a cookie
   end
 ```
+
+The SSB URI **MAY** also contain the query parameter `multiserverAddress` with value `msaddr` matching the server's multiserver address, in case the client does not know how to map the server's `sid` to a multiserver address in order to call the muxrpc `http.sendSolution`:
+
+```
+ssb:experimental?<br/>action=start-http-auth&sid=${sid}&sc=${sc}&multiserverAddress=${msaddr}
+```


### PR DESCRIPTION
From a thread with mixmix, I realized that the current spec assumes that the client already knows the server (e.g. is already a member of the room), but in the more general case where there's a random website that wants to allow you to login with SSB, the client may not know beforehand the website's multiserver address. So this is a simple addition to the SSB URI in the server-initiated case.

@cryptix We could even implement this in go-ssb-room, even though it's not strictly required. But it could help for the following scenario:

- Alice adds Bob as a member, inputting Bob's SSB ID
- Bob goes to the room's page, confident that he knows he's a member (despite never having connected to the room via muxrpc)
- Bob wants to sign-in with SSB but his SSB app doesn't know the multiserver address of the room